### PR TITLE
Add 'qualifiedBidder' and 'disqualifiedBidder' codes to +partyRole.csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 This extension was originally discussed in <https://github.com/open-contracting-extensions/public-private-partnerships/issues/36>.
 
+### 2019-05-01
+
+* Add 'qualifiedBidder' and 'disqualifiedBidder' codes to `+partyRole.csv`.
+
 ### 2019-03-20
 
 * Set `"uniqueItems": true` on array fields, and add `"minLength": 1` on required string fields.

--- a/codelists/+partyRole.csv
+++ b/codelists/+partyRole.csv
@@ -1,0 +1,3 @@
+Code,Title,Description,Source
+qualifiedBidder,Qualified bidder,Those parties invited to submit a proposal in response to a Request for Proposal (RFP) for a project in which the government only allows a limited number of pre-qualified bidders to proceed to the RFP phase.,https://ppp-certification.com/ppp-certification-guide/glossary
+disqualifiedBidder,Disqualified bidder,A bidder which either did not pass the qualification stage of the evaluation process or did not pass the pre-qualification stage of the process.,

--- a/extension.json
+++ b/extension.json
@@ -12,6 +12,7 @@
     "1.1"
   ],
   "codelists": [
+    "+partyRole.csv",
     "preQualificationStatus.csv"
   ],
   "schemas": [


### PR DESCRIPTION
OCDS uses 'tenderer' instead of 'bidder' from OCDS for PPPs. I don't know if we want to align, i.e. 'qualifiedTenderer' and 'disqualifiedTenderer', in which case we wouldn't merge https://github.com/open-contracting-extensions/ocds_ppp_extension/pull/8